### PR TITLE
TLDR-2430: auth hidden LDAP users by admin binding

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -11,7 +11,7 @@ Devise.setup do |config|
   # config.ldap_check_group_membership = false
   # config.ldap_check_group_membership_without_admin = false
   # config.ldap_check_attributes = false
-  config.ldap_use_admin_to_bind = false
+  config.ldap_use_admin_to_bind = Rails.env.production? ? true : false
   # config.ldap_ad_group_check = false
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing


### PR DESCRIPTION
Currently, there is an issue with hidden users in LDAP finding themselves unable to login into TDL.  We've previously cleaned this up in MIRA, so I'm applying a similar fix here.  Also, taking to account the desire to have a dummy sample ldap config for docker/gh.