### PR TITLE
DCA/TARC name change: NNV descriptive text

### DIFF
--- a/app/views/hyrax/voting_records/show.html.erb
+++ b/app/views/hyrax/voting_records/show.html.erb
@@ -15,7 +15,7 @@
         <span class="glyphicon glyphicon-arrow-right"></span></h5>
       <strong>A New Nation Votes</strong> is a searchable collection of election returns from the earliest years
       of American democracy. The data were compiled by Philip Lampi, and are made available online by The
-      American Antiquarian Society and Tufts University Digital Collections and Archives, with funding from the
+      American Antiquarian Society and Tufts Archival Research Center, with funding from the
       National Endowment for the Humanities. The election records have a dedicated portal which allows you to
       narrow your search by candidate, office, year, or state.
     </div>


### PR DESCRIPTION
Separating out https://tuftswork.atlassian.net/browse/TDLR-2455 into its own piece.
One small step in the DCA TARC name change.