### PR TITLE
route needs to support both verbs for an internal redirect

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
   if Rails.env.production? || Rails.env.stage?
     devise_for :users, controllers: { omniauth_callbacks: "omniauthcallbacks" }, skip: [:sessions]
     devise_scope :user do
-      post 'sign_in', to: 'omniauth#new', as: :new_user_session
+      match 'sign_in', to: 'omniauth#new', as: :new_user_session, via: [:get, :post]
       post 'sign_in', to: 'omniauth_callbacks#shibboleth', as: :new_session
       get 'sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
     end


### PR DESCRIPTION
The way handles on non-public objects get redirected, we need to support GET and POST here rather than just POST.  Currently, this sort of deep linking 302s to /sign_in which the route doesn't exist in a shibboleth world.