### PR TITLE
more gracefully deal with new user creation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,11 +78,20 @@ class User < ApplicationRecord
   def self.from_omniauth(auth)
     Rails.logger.warn "auth = #{auth.inspect}"
     # Uncomment the debugger above to capture what a shib auth object looks like for testing
-    user = where(username: auth[:uid]).first_or_create
-    user.display_name = auth[:name]
-    user.username = auth[:uid]
-    user.email = auth[:mail]
-    user.save
+    user = find_by(username: auth[:uid])
+    if user.nil?
+      user = User.create(
+        email: auth[:mail],
+        username: auth[:uid],
+        display_name: auth[:name]
+
+      )
+    else
+      user.display_name = auth[:name]
+      user.username = auth[:uid]
+      user.email = auth[:mail]
+      user.save
+    end
     user
   end
 end


### PR DESCRIPTION
The original implementation of `first_or_create` is a bit clumsy.  where isn't preferred, and first_or_create here doesn't actually *always* create, and we want to locally update the preferred name from identity provider if it changes, this implementation at least does those things.  That warn should get pulled at some point but it makes it way easier to debug live identity issues and we've had two since rolling out shib.