### PR TITLE
Video w/SRT support in Generic Objects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ group :development do
 end
 
 gem 'hyrax', '2.9.5'
-gem 'tufts-curation', git: 'https://github.com/TuftsUniversity/tufts-curation', tag: 'v1.3.0'
+gem 'tufts-curation', git: 'https://github.com/TuftsUniversity/tufts-curation', tag: 'v1.3.1'
 
 group :development, :test do
   gem 'solr_wrapper', '>= 0.3'

--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ group :development do
 end
 
 gem 'hyrax', '2.9.5'
-gem 'tufts-curation', git: 'https://github.com/TuftsUniversity/tufts-curation', branch: 'add_transcription_schema' #tag: 'v1.3.0'
+gem 'tufts-curation', git: 'https://github.com/TuftsUniversity/tufts-curation', tag: 'v1.3.0'
 
 group :development, :test do
   gem 'solr_wrapper', '>= 0.3'

--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,7 @@ group :test do
   gem 'factory_bot_rails'
   gem 'ffaker'
   gem 'ladle'
+  gem 'rails-controller-testing'
   gem 'simplecov'
   gem 'simplecov-lcov', '~> 0.8.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ group :development do
 end
 
 gem 'hyrax', '2.9.5'
-gem 'tufts-curation', git: 'https://github.com/TuftsUniversity/tufts-curation', tag: 'v1.3.0'
+gem 'tufts-curation', git: 'https://github.com/TuftsUniversity/tufts-curation', branch: 'add_transcription_schema' #tag: 'v1.3.0'
 
 group :development, :test do
   gem 'solr_wrapper', '>= 0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -717,6 +717,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.2.5)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -1038,6 +1042,7 @@ DEPENDENCIES
   puma (~> 3.12)
   rack (>= 2.0.6)
   rails (= 5.2.5)
+  rails-controller-testing
   recaptcha
   riiif!
   rsolr (>= 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,8 +19,8 @@ GIT
 
 GIT
   remote: https://github.com/TuftsUniversity/tufts-curation
-  revision: ff29ef21cb9fe97cf67e4de393e3f0104bf367c6
-  tag: v1.3.0
+  revision: 89a9db481cc9e9efb68f6966128948b06aaf57a0
+  branch: add_transcription_schema
   specs:
     tufts-curation (0.1.0)
       active-fedora (>= 11.5, <= 12.99)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,8 +19,8 @@ GIT
 
 GIT
   remote: https://github.com/TuftsUniversity/tufts-curation
-  revision: ff29ef21cb9fe97cf67e4de393e3f0104bf367c6
-  tag: v1.3.0
+  revision: 508861ddb02eed7dc72214a368949fe1021d6303
+  tag: v1.3.1
   specs:
     tufts-curation (0.1.0)
       active-fedora (>= 11.5, <= 12.99)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,8 +19,8 @@ GIT
 
 GIT
   remote: https://github.com/TuftsUniversity/tufts-curation
-  revision: 89a9db481cc9e9efb68f6966128948b06aaf57a0
-  branch: add_transcription_schema
+  revision: ff29ef21cb9fe97cf67e4de393e3f0104bf367c6
+  tag: v1.3.0
   specs:
     tufts-curation (0.1.0)
       active-fedora (>= 11.5, <= 12.99)

--- a/app/controllers/concerns/with_transcripts.rb
+++ b/app/controllers/concerns/with_transcripts.rb
@@ -31,7 +31,7 @@ module WithTranscripts
       if file.mime_type == "text/xml"
         @document_tei = Datastreams::Tei.from_xml(file.content)
         @document_tei&.ng_xml&.remove_namespaces!
-      elsif file.mime_type == "text/plain"
+      elsif file.mime_type == "text/plain"  || file.mime_type == "text/vtt" || file.mime_type == "text/srt"
         @has_srt = true
         @srt_id = file_set_id
       end
@@ -40,12 +40,15 @@ module WithTranscripts
     private
 
       def process_valid_file_sets(file_sets)
-        file_sets.each do |file_set|
-          next unless valid_file_type?(file_set.original_file)
-          next if transcript_embargo? file_set
-          define_file_settings(file_set.original_file, file_set.id)
-          break
-        end
+        file_set = @document_fedora.transcript
+        return if transcript_embargo? file_set
+        define_file_settings(file_set.original_file, file_set.id)
+        #file_sets.each do |file_set|
+        #  next unless valid_file_type?(file_set.original_file)
+        #  next
+        #  define_file_settings(file_set.original_file, file_set.id)
+        #  break
+        #end
       end
   end
   # rubocop:enable Metrics/BlockLength

--- a/app/controllers/concerns/with_transcripts.rb
+++ b/app/controllers/concerns/with_transcripts.rb
@@ -16,7 +16,7 @@ module WithTranscripts
       file_sets = @document_fedora.file_sets
       return if file_sets.nil?
 
-      process_valid_file_sets(file_sets)
+      process_valid_file_sets
     end
 
     def transcript_embargo?(file_set)
@@ -39,10 +39,12 @@ module WithTranscripts
 
     private
 
-      def process_valid_file_sets(file_sets)
+      def process_valid_file_sets
         file_set = @document_fedora.transcript
-        return if transcript_embargo? file_set
-        define_file_settings(file_set.original_file, file_set.id)
+        if file_set
+          return if transcript_embargo? file_set
+          define_file_settings(file_set.original_file, file_set.id)
+        end
         #file_sets.each do |file_set|
         #  next unless valid_file_type?(file_set.original_file)
         #  next

--- a/app/controllers/concerns/with_transcripts.rb
+++ b/app/controllers/concerns/with_transcripts.rb
@@ -31,7 +31,7 @@ module WithTranscripts
       if file.mime_type == "text/xml"
         @document_tei = Datastreams::Tei.from_xml(file.content)
         @document_tei&.ng_xml&.remove_namespaces!
-      elsif file.mime_type == "text/plain"  || file.mime_type == "text/vtt" || file.mime_type == "text/srt"
+      elsif file.mime_type == "text/plain" || file.mime_type == "text/vtt" || file.mime_type == "text/srt"
         @has_srt = true
         @srt_id = file_set_id
       end
@@ -45,12 +45,6 @@ module WithTranscripts
           return if transcript_embargo? file_set
           define_file_settings(file_set.original_file, file_set.id)
         end
-        #file_sets.each do |file_set|
-        #  next unless valid_file_type?(file_set.original_file)
-        #  next
-        #  define_file_settings(file_set.original_file, file_set.id)
-        #  break
-        #end
       end
   end
   # rubocop:enable Metrics/BlockLength

--- a/app/controllers/concerns/with_transcripts.rb
+++ b/app/controllers/concerns/with_transcripts.rb
@@ -41,10 +41,9 @@ module WithTranscripts
 
       def process_valid_file_sets
         file_set = @document_fedora.transcript
-        if file_set
-          return if transcript_embargo? file_set
-          define_file_settings(file_set.original_file, file_set.id)
-        end
+        return unless file_set
+        return if transcript_embargo? file_set
+        define_file_settings(file_set.original_file, file_set.id)
       end
   end
   # rubocop:enable Metrics/BlockLength

--- a/app/controllers/concerns/with_transcripts.rb
+++ b/app/controllers/concerns/with_transcripts.rb
@@ -13,8 +13,6 @@ module WithTranscripts
       @document_tei = nil
       @has_srt = false
       @srt_id = ""
-      return unless @document_fedora.instance_of?(Audio) || @document_fedora.instance_of?(Video)
-
       file_sets = @document_fedora.file_sets
       return if file_sets.nil?
 

--- a/app/controllers/concerns/with_transcripts.rb
+++ b/app/controllers/concerns/with_transcripts.rb
@@ -31,7 +31,7 @@ module WithTranscripts
       if file.mime_type == "text/xml"
         @document_tei = Datastreams::Tei.from_xml(file.content)
         @document_tei&.ng_xml&.remove_namespaces!
-      elsif file.mime_type == "text/plain" || file.mime_type == "text/vtt" || file.mime_type == "text/srt"
+      elsif ["text/plain", "text/vtt", "text/srt"].include?(file.mime_type)
         @has_srt = true
         @srt_id = file_set_id
       end

--- a/app/controllers/hyrax/generic_objects_controller.rb
+++ b/app/controllers/hyrax/generic_objects_controller.rb
@@ -3,6 +3,7 @@ module Hyrax
   class GenericObjectsController < ApplicationController
     include Hyrax::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
+    include WithTranscripts
     include WithShowEnforcement
 
     before_action :enforce_show_permissions, only: :show

--- a/app/controllers/hyrax/generic_objects_controller.rb
+++ b/app/controllers/hyrax/generic_objects_controller.rb
@@ -8,6 +8,8 @@ module Hyrax
 
     before_action :enforce_show_permissions, only: :show
 
+    before_action :load_fedora_document
+
     self.curation_concern_type = ::GenericObject
     self.show_presenter = Hyrax::GenericObjectPresenter
     def advanced

--- a/app/views/hyrax/generic_objects/show.html.erb
+++ b/app/views/hyrax/generic_objects/show.html.erb
@@ -64,3 +64,7 @@ table tr>th:nth-of-type(4),   table tr>td:nth-of-type(4){
 </div>
 <% end %>
 </div>
+<script>
+  $(document).ready(function() {
+    $('video, audio').mediaelementplayer();
+</script>

--- a/app/views/hyrax/generic_objects/show.html.erb
+++ b/app/views/hyrax/generic_objects/show.html.erb
@@ -1,13 +1,14 @@
 <%= render "shared/item_header" %>
 <% collector = can?(:collect, @presenter.id) %>
-<% 
-   editor = can?(:edit, @presenter.id) 
+<%
+   editor = can?(:edit, @presenter.id)
    file_set_id = @presenter.solr_document._source["hasRelatedImage_ssim"]
    file_set = FileSet.find(file_set_id).first
    file_sets = @presenter.solr_document._source["file_set_ids_ssim"]
    has_images = false
-   primary_is_image = false
-   primary_is_image = true if file_set.mime_type.include?('image/')
+   has_transcript = false
+   primary_is_image = file_set.mime_type.include?('image/') ? true : false
+   primary_is_video = file_set.mime_type.include?('video') ? true : false
 
    file_sets.each do |fs|
     results = ActiveFedora::SolrService.query(ActiveFedora::SolrQueryBuilder.construct_query(id: fs), rows: 1, fl: 'id,mime_type_ssi,visibility_ssi')
@@ -28,10 +29,19 @@ table tr>th:nth-of-type(4),   table tr>td:nth-of-type(4){
 </style>
 <div class="col-md-12 tdl-content tdl-show-image">
   <div class="row col-md-6">
-    <% if primary_is_image %> 
+    <% if primary_is_image %>
      <%= link_to "/gimageviewer/#{@presenter.id}", data: { turbolinks: false } do %>
         <%= image_tag(Riiif::Engine.routes.url_helpers.image_url(file_set.original_file.id, host: request.base_url, size: "400,")) %>
       <% end %>
+    <% elsif primary_is_video %>
+      <% video_url = "#{main_app.hls_path(fs.id)}?file=m3u8" %>
+      <video controls="controls" preload="metadata" width="445px" height="390px">
+        <source src="<%= video_url %>" type="application/x-mpegURL">
+          Your browser does not support the video tag.
+        <% if @has_srt %>
+          <track label="Captions" kind="subtitles" srclang="en" src="<%= vtt_link(@srt_id)  %>" default>
+        <% end %>
+      </video>
     <% else %>
         <%= render 'representative_media', presenter: @presenter %>
     <% end %>

--- a/app/views/hyrax/generic_objects/show.html.erb
+++ b/app/views/hyrax/generic_objects/show.html.erb
@@ -67,4 +67,5 @@ table tr>th:nth-of-type(4),   table tr>td:nth-of-type(4){
 <script>
   $(document).ready(function() {
     $('video, audio').mediaelementplayer();
+  });
 </script>

--- a/app/views/hyrax/generic_objects/show.html.erb
+++ b/app/views/hyrax/generic_objects/show.html.erb
@@ -34,7 +34,7 @@ table tr>th:nth-of-type(4),   table tr>td:nth-of-type(4){
         <%= image_tag(Riiif::Engine.routes.url_helpers.image_url(file_set.original_file.id, host: request.base_url, size: "400,")) %>
       <% end %>
     <% elsif primary_is_video %>
-      <% video_url = "#{main_app.hls_path(fs.id)}?file=m3u8" %>
+      <% video_url = "#{main_app.hls_path(file_set_id)}?file=m3u8" %>
       <video controls="controls" preload="metadata" width="445px" height="390px">
         <source src="<%= video_url %>" type="application/x-mpegURL">
           Your browser does not support the video tag.

--- a/spec/controllers/concerns/with_transcripts_spec.rb
+++ b/spec/controllers/concerns/with_transcripts_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe WithTranscripts, type: :concern do
 
   let(:params) { {} }
   let(:file_set) { instance_double("FileSet", embargo: embargo, original_file: original_file, id: "file_set_id") }
-  let(:transcript) { instance_double("FileSet", embargo: embargo, original_file: transcript_file, id: "file_set_id") }
+  let(:transcript) { instance_double("FileSet", original_file: transcript_file, id: "file_set_id2") }
   let(:transcript_file) { instance_double("OriginalFile", mime_type: "text/plain", content: "file_content") }
   let(:original_file) { instance_double("OriginalFile", mime_type: "video/mp4", content: "file_content") }
   let(:embargo) { instance_double("Embargo", embargo_release_date: "2023-05-26T00:00:00Z") }

--- a/spec/controllers/concerns/with_transcripts_spec.rb
+++ b/spec/controllers/concerns/with_transcripts_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe WithTranscripts, type: :concern do
 
   let(:params) { {} }
   let(:file_set) { instance_double("FileSet", embargo: embargo, original_file: original_file, id: "file_set_id") }
+  let(:transcript) { instance_double("FileSet", embargo: embargo, original_file: transcript_file, id: "file_set_id") }
+  let(:transcript_file) { instance_double("OriginalFile", mime_type: "text/plain", content: "file_content") }
   let(:original_file) { instance_double("OriginalFile", mime_type: "video/mp4", content: "file_content") }
   let(:embargo) { instance_double("Embargo", embargo_release_date: "2023-05-26T00:00:00Z") }
 

--- a/spec/controllers/concerns/with_transcripts_spec.rb
+++ b/spec/controllers/concerns/with_transcripts_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe WithTranscripts, type: :concern do
 
   describe '#load_fedora_document' do
     before do
-      allow(ActiveFedora::Base).to receive(:find).and_return(instance_double("Document", file_sets: [file_set]))
+      allow(ActiveFedora::Base).to receive(:find).and_return(instance_double("Document", file_sets: [file_set, transcript], transcript: transcript))
       model_instance.load_fedora_document
     end
 
@@ -40,9 +40,6 @@ RSpec.describe WithTranscripts, type: :concern do
 
     context 'when params[:id] is present' do
       let(:params) { { id: 'test_id' } }
-      let(:document_fedora) do
-        instance_double("Document", file_sets: [file_set, transcript], transcript: transcript)
-      end
 
       it 'loads the Fedora document' do
         expect(ActiveFedora::Base).to have_received(:find).with('test_id')

--- a/spec/controllers/concerns/with_transcripts_spec.rb
+++ b/spec/controllers/concerns/with_transcripts_spec.rb
@@ -38,13 +38,16 @@ RSpec.describe WithTranscripts, type: :concern do
       end
     end
 
-    context 'when params[:id] is present' do
-      let(:params) { { id: 'test_id' } }
+      context 'when params[:id] is present' do
+        let(:params) { { id: 'test_id' } }
+        let(:document_fedora) do
+          instance_double("Document", file_sets: [file_set, transcript], transcript: transcript)
+        end
 
-      it 'loads the Fedora document' do
-        expect(ActiveFedora::Base).to have_received(:find).with('test_id')
+        it 'loads the Fedora document' do
+          expect(ActiveFedora::Base).to have_received(:find).with('test_id')
+        end
       end
-    end
   end
 
   describe '#transcript_embargo?' do

--- a/spec/controllers/concerns/with_transcripts_spec.rb
+++ b/spec/controllers/concerns/with_transcripts_spec.rb
@@ -38,16 +38,16 @@ RSpec.describe WithTranscripts, type: :concern do
       end
     end
 
-      context 'when params[:id] is present' do
-        let(:params) { { id: 'test_id' } }
-        let(:document_fedora) do
-          instance_double("Document", file_sets: [file_set, transcript], transcript: transcript)
-        end
-
-        it 'loads the Fedora document' do
-          expect(ActiveFedora::Base).to have_received(:find).with('test_id')
-        end
+    context 'when params[:id] is present' do
+      let(:params) { { id: 'test_id' } }
+      let(:document_fedora) do
+        instance_double("Document", file_sets: [file_set, transcript], transcript: transcript)
       end
+
+      it 'loads the Fedora document' do
+        expect(ActiveFedora::Base).to have_received(:find).with('test_id')
+      end
+    end
   end
 
   describe '#transcript_embargo?' do

--- a/spec/controllers/concerns/with_transcripts_spec.rb
+++ b/spec/controllers/concerns/with_transcripts_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe WithTranscripts, type: :concern do
 
   let(:params) { {} }
   let(:file_set) { instance_double("FileSet", embargo: embargo, original_file: original_file, id: "file_set_id") }
-  let(:transcript) { instance_double("FileSet", original_file: transcript_file, id: "file_set_id2") }
+  let(:transcript) { instance_double("FileSet", embargo: nil, original_file: transcript_file, id: "file_set_id2") }
   let(:transcript_file) { instance_double("OriginalFile", mime_type: "text/plain", content: "file_content") }
   let(:original_file) { instance_double("OriginalFile", mime_type: "video/mp4", content: "file_content") }
   let(:embargo) { instance_double("Embargo", embargo_release_date: "2023-05-26T00:00:00Z") }

--- a/spec/controllers/concerns/with_transcripts_spec.rb
+++ b/spec/controllers/concerns/with_transcripts_spec.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 RSpec.describe WithTranscripts, type: :concern do
   # Create a mock model to include the concern for testing purposes
+  subject(:model_instance) { test_model.new(params) }
+
   let(:test_model) do
     Class.new do
       include WithTranscripts
@@ -14,24 +17,22 @@ RSpec.describe WithTranscripts, type: :concern do
     end
   end
 
-  subject { test_model.new(params) }
-
   let(:params) { {} }
-  let(:file_set) { double("FileSet", embargo: embargo, original_file: original_file, id: "file_set_id") }
-  let(:original_file) { double("OriginalFile", mime_type: "video/mp4", content: "file_content") }
-  let(:embargo) { double("Embargo", embargo_release_date: "2023-05-26T00:00:00Z") }
+  let(:file_set) { instance_double("FileSet", embargo: embargo, original_file: original_file, id: "file_set_id") }
+  let(:original_file) { instance_double("OriginalFile", mime_type: "video/mp4", content: "file_content") }
+  let(:embargo) { instance_double("Embargo", embargo_release_date: "2023-05-26T00:00:00Z") }
 
   describe '#load_fedora_document' do
     before do
-      allow(ActiveFedora::Base).to receive(:find).and_return(double("Document", file_sets: [file_set]))
+      allow(ActiveFedora::Base).to receive(:find).and_return(instance_double("Document", file_sets: [file_set]))
+      model_instance.load_fedora_document
     end
 
     context 'when params[:id] is blank' do
       let(:params) { { id: nil } }
 
       it 'does not attempt to load the document' do
-        expect(ActiveFedora::Base).not_to receive(:find)
-        subject.load_fedora_document
+        expect(ActiveFedora::Base).not_to have_received(:find)
       end
     end
 
@@ -39,18 +40,17 @@ RSpec.describe WithTranscripts, type: :concern do
       let(:params) { { id: 'test_id' } }
 
       it 'loads the Fedora document' do
-        expect(ActiveFedora::Base).to receive(:find).with('test_id')
-        subject.load_fedora_document
+        expect(ActiveFedora::Base).to have_received(:find).with('test_id')
       end
     end
   end
 
   describe '#transcript_embargo?' do
     context 'when file_set has embargo with release date' do
-      let(:embargo_release_date) { Date.today + 1.day }
+      let(:embargo_release_date) { Time.zone.today + 1.day }
 
       it 'returns true' do
-        expect(subject.transcript_embargo?(file_set)).to be_truthy
+        expect(model_instance.transcript_embargo?(file_set)).to be_truthy
       end
     end
 
@@ -58,41 +58,26 @@ RSpec.describe WithTranscripts, type: :concern do
       let(:embargo) { nil }
 
       it 'returns false' do
-        expect(subject.transcript_embargo?(file_set)).to be_falsey
+        expect(model_instance.transcript_embargo?(file_set)).to be_falsey
       end
     end
   end
 
   describe '#valid_file_type?' do
     context 'when file has a valid mime type' do
-      let(:original_file) { double("OriginalFile", mime_type: "text/xml", content: "file_content") }
+      let(:original_file) { instance_double("OriginalFile", mime_type: "text/xml", content: "file_content") }
 
-      before do
-        allow(original_file).to receive(:present?).and_return(true)
-      end
       it 'returns true' do
-        expect(subject.valid_file_type?(original_file)).to be_truthy
+        expect(model_instance.valid_file_type?(original_file)).to be_truthy
       end
     end
 
     context 'when file does not have a valid mime type' do
-      let(:original_file) { double("OriginalFile", mime_type: "invalid/type", content: "file_content") }
+      let(:original_file) { instance_double("OriginalFile", mime_type: "invalid/type", content: "file_content") }
 
       it 'returns false' do
-        expect(subject.valid_file_type?(original_file)).to be_falsey
+        expect(model_instance.valid_file_type?(original_file)).to be_falsey
       end
-    end
-  end
-
-  describe '#process_valid_file_sets' do
-    before do
-      allow(subject).to receive(:valid_file_type?).and_return(true)
-      allow(subject).to receive(:transcript_embargo?).and_return(false)
-    end
-
-    it 'processes valid file sets' do
-      expect(subject).to receive(:define_file_settings).with(original_file, "file_set_id")
-      subject.send(:process_valid_file_sets, [file_set])
     end
   end
 end

--- a/spec/controllers/concerns/with_transcripts_spec.rb
+++ b/spec/controllers/concerns/with_transcripts_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.describe WithTranscripts, type: :concern do
+  # Create a mock model to include the concern for testing purposes
+  let(:test_model) do
+    Class.new do
+      include WithTranscripts
+
+      attr_accessor :params
+
+      def initialize(params = {})
+        @params = params
+      end
+    end
+  end
+
+  subject { test_model.new(params) }
+
+  let(:params) { {} }
+  let(:file_set) { double("FileSet", embargo: embargo, original_file: original_file, id: "file_set_id") }
+  let(:original_file) { double("OriginalFile", mime_type: "video/mp4", content: "file_content") }
+  let(:embargo) { double("Embargo", embargo_release_date: "2023-05-26T00:00:00Z") }
+
+  describe '#load_fedora_document' do
+    before do
+      allow(ActiveFedora::Base).to receive(:find).and_return(double("Document", file_sets: [file_set]))
+    end
+
+    context 'when params[:id] is blank' do
+      let(:params) { { id: nil } }
+
+      it 'does not attempt to load the document' do
+        expect(ActiveFedora::Base).not_to receive(:find)
+        subject.load_fedora_document
+      end
+    end
+
+    context 'when params[:id] is present' do
+      let(:params) { { id: 'test_id' } }
+
+      it 'loads the Fedora document' do
+        expect(ActiveFedora::Base).to receive(:find).with('test_id')
+        subject.load_fedora_document
+      end
+    end
+  end
+
+  describe '#transcript_embargo?' do
+    context 'when file_set has embargo with release date' do
+      let(:embargo_release_date) { Date.today + 1.day }
+
+      it 'returns true' do
+        expect(subject.transcript_embargo?(file_set)).to be_truthy
+      end
+    end
+
+    context 'when file_set does not have embargo or release date' do
+      let(:embargo) { nil }
+
+      it 'returns false' do
+        expect(subject.transcript_embargo?(file_set)).to be_falsey
+      end
+    end
+  end
+
+  describe '#valid_file_type?' do
+    context 'when file has a valid mime type' do
+      let(:original_file) { double("OriginalFile", mime_type: "text/xml", content: "file_content") }
+
+      before do
+        allow(original_file).to receive(:present?).and_return(true)
+      end
+      it 'returns true' do
+        expect(subject.valid_file_type?(original_file)).to be_truthy
+      end
+    end
+
+    context 'when file does not have a valid mime type' do
+      let(:original_file) { double("OriginalFile", mime_type: "invalid/type", content: "file_content") }
+
+      it 'returns false' do
+        expect(subject.valid_file_type?(original_file)).to be_falsey
+      end
+    end
+  end
+
+  describe '#process_valid_file_sets' do
+    before do
+      allow(subject).to receive(:valid_file_type?).and_return(true)
+      allow(subject).to receive(:transcript_embargo?).and_return(false)
+    end
+
+    it 'processes valid file sets' do
+      expect(subject).to receive(:define_file_settings).with(original_file, "file_set_id")
+      subject.send(:process_valid_file_sets, [file_set])
+    end
+  end
+end

--- a/spec/controllers/concerns/with_transcripts_spec.rb
+++ b/spec/controllers/concerns/with_transcripts_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe WithTranscripts, type: :concern do
 
   describe '#load_fedora_document' do
     before do
-      allow(ActiveFedora::Base).to receive(:find).and_return(instance_double("Document", file_sets: [file_set, transcript], transcript: transcript))
+      allow(ActiveFedora::Base).to receive(:find).and_return(instance_double("Document", file_sets: [file_set, transcript], transcript: transcript, embargo: nil))
       model_instance.load_fedora_document
     end
 

--- a/spec/controllers/hyrax/generic_object_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_object_controller_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 RSpec.describe Hyrax::GenericObjectsController, type: :controller do
   routes { Rails.application.routes }
 
-
   let(:generic_object) { FactoryBot.create(:generic_object_with_xml) }
 
   describe 'GET #advanced' do
@@ -12,7 +11,6 @@ RSpec.describe Hyrax::GenericObjectsController, type: :controller do
       before do
         get :advanced, params: { id: generic_object.id }
         request.env['warden'] = instance_double("Warden::Proxy").as_null_object
-
       end
 
       it 'assigns the correct id' do

--- a/spec/controllers/hyrax/generic_object_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_object_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Hyrax::GenericObjectsController, type: :controller do
+  routes { Rails.application.routes }
+
+
+  let(:generic_object) { FactoryBot.create(:generic_object_with_xml) }
+
+  describe 'GET #advanced' do
+    context 'when the object exists' do
+      before do
+        get :advanced, params: { id: generic_object.id }
+        request.env['warden'] = instance_double("Warden::Proxy").as_null_object
+
+      end
+
+      it 'assigns the correct id' do
+        expect(assigns(:id)).to eq(generic_object.id)
+      end
+
+      it 'renders the imageviewer layout' do
+        expect(response).to render_template(layout: 'imageviewer')
+      end
+
+      it 'responds with success' do
+        expect(response).to be_successful
+      end
+    end
+
+    context 'when the object does not exist' do
+      it 'raises a record not found error' do
+        expect do
+          get :advanced, params: { id: 'nonexistent' }
+        end.to raise_error(ActiveFedora::ObjectNotFoundError)
+      end
+    end
+  end
+end

--- a/spec/factories/audio.rb
+++ b/spec/factories/audio.rb
@@ -40,6 +40,8 @@ FactoryBot.define do
           original_file.content = transcript_test_file
           file_set.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
           file_set.save
+          work.transcript = file_set
+          work.transcript_id = '1234jt5tr'
         end
       end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -139,6 +139,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.order = "random"
   config.include Capybara::DSL
+  config.include Devise::Test::ControllerHelpers, type: :controller
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)


### PR DESCRIPTION
Reference: TDLR-2509 support for videos with captions in Genric objects

- also adds controller tests for generic objects controller
- adds concerns tests for with_transcripts
- sets up test support for controllers
- adds support to generic objects for captions, our generic object use cases are a bit loose talked to TARC about this one and we'll treat plain text when the primary object is video as a transcript.