### PR TITLE
String in GA Javascript is not quoted

### DIFF
--- a/app/views/analytics/_ga.html.erb
+++ b/app/views/analytics/_ga.html.erb
@@ -9,7 +9,7 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', <%= api_key %>);
+  gtag('config', '<%= api_key %>');
 </script>
 <% end %>
 


### PR DESCRIPTION
causes a syntax error in the javascript console