### PR TITLE
Hide Transcript from list of sub-objects on Generic Object

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Setup hyrax test environment
       run: |
         bundle exec rake hydra:test_server &
-        sleep 240
+        sleep 280
     - name: Rubbocop
       run: |
         bundle exec rubocop

--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -52,7 +52,7 @@ module HyraxHelper
         download_links << add_to_list_link
         download_links << pdf_link(@presenter.solr_document._source['hasRelatedMediaFragment_ssim'])
       when 'rcrs'
-        download_links << eac_link(@presenter.rcr_id) if @document_rcr.present?
+        download_links << eac_link(@presenter.rcr_id) if @document_rcr.present? && @presenter.rcr_id
       when 'videos'
         download_links << add_to_list_link
         download_links << video_link(@presenter.media_id)

--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -52,7 +52,7 @@ module HyraxHelper
         download_links << add_to_list_link
         download_links << pdf_link(@presenter.solr_document._source['hasRelatedMediaFragment_ssim'])
       when 'rcrs'
-        download_links << eac_link(@presenter.rcr_id) if @document_rcr.present? && @presenter.rcr_id
+        download_links << eac_link(@presenter.rcr_id) if @document_rcr.present? && !@presenter.rcr_id.nil?
       when 'videos'
         download_links << add_to_list_link
         download_links << video_link(@presenter.media_id)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -41,4 +41,8 @@ class SolrDocument
     source: "source_tesim",
     rights: 'rights_note_tesim'
   )
+
+  def transcript_id
+    fetch("transcription_of_ssim", [])
+  end
 end

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -22,11 +22,11 @@ module Hyrax
     # @param [Class] presenter_class the type of presenter to build
     # @return [Array<presenter_class>] presenters for the ordered_members (not filtered by class)
     def member_presenters(ids = ordered_ids, presenter_class = composite_presenter_class)
-      a = PresenterFactory.build_for(ids: ids,
+      presenter_factory = PresenterFactory.build_for(ids: ids,
                                      presenter_class: presenter_class,
                                      presenter_args: presenter_factory_arguments)
-      a.reject! { |presenter| presenter.id == @work.transcript_id.first } if @work.respond_to?(:transcript_id) && @work.transcript_id && !@work.transcript_id.first.nil?
-      a
+      presenter_factory.reject! { |presenter| presenter.id == @work.transcript_id.first } if presenter_factory && @work.respond_to?(:transcript_id) && @work.transcript_id && !@work.transcript_id.first.nil?
+      presenter_factory
     end
 
     # @return [Array<FileSetPresenter>] presenters for the orderd_members that are FileSets

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -22,7 +22,6 @@ module Hyrax
     # @param [Class] presenter_class the type of presenter to build
     # @return [Array<presenter_class>] presenters for the ordered_members (not filtered by class)
     def member_presenters(ids = ordered_ids, presenter_class = composite_presenter_class)
-
       a = PresenterFactory.build_for(ids: ids,
                                      presenter_class: presenter_class,
                                      presenter_args: presenter_factory_arguments)

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -23,9 +23,11 @@ module Hyrax
     # @return [Array<presenter_class>] presenters for the ordered_members (not filtered by class)
     def member_presenters(ids = ordered_ids, presenter_class = composite_presenter_class)
       presenter_factory = PresenterFactory.build_for(ids: ids,
-                                     presenter_class: presenter_class,
-                                     presenter_args: presenter_factory_arguments)
-      presenter_factory.reject! { |presenter| presenter.id == @work.transcript_id.first } if presenter_factory && @work.respond_to?(:transcript_id) && @work.transcript_id && !@work.transcript_id.first.nil?
+                                                     presenter_class: presenter_class,
+                                                     presenter_args: presenter_factory_arguments)
+      if presenter_factory && @work.respond_to?(:transcript_id) && @work.transcript_id && !@work.transcript_id.first.nil?
+        presenter_factory.reject! { |presenter| presenter.id == @work.transcript_id.first }
+      end
       presenter_factory
     end
 

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -25,6 +25,7 @@ module Hyrax
       presenter_factory = PresenterFactory.build_for(ids: ids,
                                                      presenter_class: presenter_class,
                                                      presenter_args: presenter_factory_arguments)
+      return if presenter_factory.nil?
       presenter_factory&.reject! { |presenter| presenter.id == @work.transcript_id.first } if @work.respond_to?(:transcript_id) && @work.transcript_id && !@work.transcript_id.first.nil?
       presenter_factory
     end
@@ -32,12 +33,15 @@ module Hyrax
     # @return [Array<FileSetPresenter>] presenters for the orderd_members that are FileSets
     def file_set_presenters
       @file_set_presenters ||= member_presenters(ordered_ids & file_set_ids)
+      return if @file_set_presenters.nil?
       @file_set_presenters.reject! { |presenter| presenter.id == @work.transcript_id } if @work.respond_to?(:transcript_id) && @work.transcript_id
     end
 
     # @return [Array<WorkShowPresenter>] presenters for the ordered_members that are not FileSets
     def work_presenters
       @work_presenters ||= member_presenters(ordered_ids - file_set_ids, work_presenter_class)
+
+      return if @work_presentners.nil?
       @work_presenters.reject! { |presenter| presenter.id == @work.transcript_id } if @work.respond_to?(:transcript_id) && @work.transcript_id
     end
 

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -21,14 +21,25 @@ module Hyrax
     # @param [Class] presenter_class the type of presenter to build
     # @return [Array<presenter_class>] presenters for the ordered_members (not filtered by class)
     def member_presenters(ids = ordered_ids, presenter_class = composite_presenter_class)
-      PresenterFactory.build_for(ids: ids,
+      Rails.logger.error "1 Respond to? : #{@work.respond_to?(:transcription)}"
+      Rails.logger.error "work : #{@work.methods}"
+      Rails.logger.error "work : #{@work.class.to_s}"
+
+      a = PresenterFactory.build_for(ids: ids,
                                  presenter_class: presenter_class,
                                  presenter_args: presenter_factory_arguments)
+     Rails.logger.error "FFFF : #{@work.transcript_id}"
+     if @work.respond_to?(:transcript_id) && @work.transcript_id && @work.transcript_id.first != nil
+       a.reject! { |presenter| presenter.id == @work.transcript_id.first}
+     end
+     a
     end
 
     # @return [Array<FileSetPresenter>] presenters for the orderd_members that are FileSets
     def file_set_presenters
       @file_set_presenters ||= member_presenters(ordered_ids & file_set_ids)
+      Rails.logger.error "2 Respond to? : #{@work.respond_to?(:transcription)}"
+      Rails.logger.error "work : #{@work.to_s}"
       if @work.respond_to?(:transcript_id) && @work.transcript_id
         @file_set_presenters.reject! { |presenter| presenter.id == @work.transcript_id }
       end
@@ -37,9 +48,17 @@ module Hyrax
     # @return [Array<WorkShowPresenter>] presenters for the ordered_members that are not FileSets
     def work_presenters
       @work_presenters ||= member_presenters(ordered_ids - file_set_ids, work_presenter_class)
+      Rails.logger.error "3 Respond to? : #{@work.respond_to?(:transcription)}"
+      Rails.logger.error "work : #{@work.to_s}"
+      if @work.respond_to?(:transcript_id) && @work.transcript_id
+        @work_presenters.reject! { |presenter| presenter.id == @work.transcript_id }
+      end
     end
 
     def ordered_ids
+      Rails.logger.error "4i Respond to? : #{@work.respond_to?(:transcription)}"
+      Rails.logger.error "work : #{@work.class.to_s}"
+      Rails.logger.error "work : #{@work.to_s}"
       @ordered_ids ||= Hyrax::SolrDocument::OrderedMembers.decorate(@work).ordered_member_ids
     end
 

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -25,8 +25,8 @@ module Hyrax
       presenter_factory = PresenterFactory.build_for(ids: ids,
                                                      presenter_class: presenter_class,
                                                      presenter_args: presenter_factory_arguments)
-      if presenter_factory && @work.respond_to?(:transcript_id) && @work.transcript_id && !@work.transcript_id.first.nil?
-        presenter_factory.reject! { |presenter| presenter.id == @work.transcript_id.first }
+      if  && @work.respond_to?(:transcript_id) && @work.transcript_id && !@work.transcript_id.first.nil?
+        presenter_factory.reject! { |presenter| presenter.id == @work.transcript_id.first } unless presenter_factory.nil?
       end
       presenter_factory
     end

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
+#
+# This is an override of Hyrax's Hyrax::MemberPresenterFactory, intended to reject transcripts from being included
+# as members of works, this is done with changes to member_presenters, work_presenters, and file_set_presenters.
+# It related to work performed as part of TDLR-2509, where transcripts need to be associated with videos in generic
+# objects for accessibilty purposes, but TARC felt they cluttered the UI.
+#
 module Hyrax
   # Creates the presenters of the members (member works and file sets) of a specific object
   class MemberPresenterFactory

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -25,9 +25,7 @@ module Hyrax
       presenter_factory = PresenterFactory.build_for(ids: ids,
                                                      presenter_class: presenter_class,
                                                      presenter_args: presenter_factory_arguments)
-      if  && @work.respond_to?(:transcript_id) && @work.transcript_id && !@work.transcript_id.first.nil?
-        presenter_factory.reject! { |presenter| presenter.id == @work.transcript_id.first } unless presenter_factory.nil?
-      end
+      presenter_factory&.reject! { |presenter| presenter.id == @work.transcript_id.first } if @work.respond_to?(:transcript_id) && @work.transcript_id && !@work.transcript_id.first.nil?
       presenter_factory
     end
 

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hyrax
   # Creates the presenters of the members (member works and file sets) of a specific object
   class MemberPresenterFactory
@@ -21,44 +22,27 @@ module Hyrax
     # @param [Class] presenter_class the type of presenter to build
     # @return [Array<presenter_class>] presenters for the ordered_members (not filtered by class)
     def member_presenters(ids = ordered_ids, presenter_class = composite_presenter_class)
-      Rails.logger.error "1 Respond to? : #{@work.respond_to?(:transcription)}"
-      Rails.logger.error "work : #{@work.methods}"
-      Rails.logger.error "work : #{@work.class.to_s}"
 
       a = PresenterFactory.build_for(ids: ids,
-                                 presenter_class: presenter_class,
-                                 presenter_args: presenter_factory_arguments)
-     Rails.logger.error "FFFF : #{@work.transcript_id}"
-     if @work.respond_to?(:transcript_id) && @work.transcript_id && @work.transcript_id.first != nil
-       a.reject! { |presenter| presenter.id == @work.transcript_id.first}
-     end
-     a
+                                     presenter_class: presenter_class,
+                                     presenter_args: presenter_factory_arguments)
+      a.reject! { |presenter| presenter.id == @work.transcript_id.first } if @work.respond_to?(:transcript_id) && @work.transcript_id && !@work.transcript_id.first.nil?
+      a
     end
 
     # @return [Array<FileSetPresenter>] presenters for the orderd_members that are FileSets
     def file_set_presenters
       @file_set_presenters ||= member_presenters(ordered_ids & file_set_ids)
-      Rails.logger.error "2 Respond to? : #{@work.respond_to?(:transcription)}"
-      Rails.logger.error "work : #{@work.to_s}"
-      if @work.respond_to?(:transcript_id) && @work.transcript_id
-        @file_set_presenters.reject! { |presenter| presenter.id == @work.transcript_id }
-      end
+      @file_set_presenters.reject! { |presenter| presenter.id == @work.transcript_id } if @work.respond_to?(:transcript_id) && @work.transcript_id
     end
 
     # @return [Array<WorkShowPresenter>] presenters for the ordered_members that are not FileSets
     def work_presenters
       @work_presenters ||= member_presenters(ordered_ids - file_set_ids, work_presenter_class)
-      Rails.logger.error "3 Respond to? : #{@work.respond_to?(:transcription)}"
-      Rails.logger.error "work : #{@work.to_s}"
-      if @work.respond_to?(:transcript_id) && @work.transcript_id
-        @work_presenters.reject! { |presenter| presenter.id == @work.transcript_id }
-      end
+      @work_presenters.reject! { |presenter| presenter.id == @work.transcript_id } if @work.respond_to?(:transcript_id) && @work.transcript_id
     end
 
     def ordered_ids
-      Rails.logger.error "4i Respond to? : #{@work.respond_to?(:transcription)}"
-      Rails.logger.error "work : #{@work.class.to_s}"
-      Rails.logger.error "work : #{@work.to_s}"
       @ordered_ids ||= Hyrax::SolrDocument::OrderedMembers.decorate(@work).ordered_member_ids
     end
 

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -30,7 +30,7 @@ module Hyrax
     def file_set_presenters
       @file_set_presenters ||= member_presenters(ordered_ids & file_set_ids)
       if @work.respond_to?(:transcript_id) && @work.transcript_id
-        file_set_presenters.reject! { |presenter| presenter.id == @work.transcript_id }
+        @file_set_presenters.reject! { |presenter| presenter.id == @work.transcript_id }
       end
     end
 

--- a/app/presenters/hyrax/member_presenter_factory.rb
+++ b/app/presenters/hyrax/member_presenter_factory.rb
@@ -1,0 +1,69 @@
+module Hyrax
+  # Creates the presenters of the members (member works and file sets) of a specific object
+  class MemberPresenterFactory
+    class_attribute :file_presenter_class, :work_presenter_class
+    # modify this attribute to use an alternate presenter class for the files
+    self.file_presenter_class = FileSetPresenter
+
+    # modify this attribute to use an alternate presenter class for the child works
+    self.work_presenter_class = WorkShowPresenter
+
+    def initialize(work, ability, request = nil)
+      @work = work
+      @current_ability = ability
+      @request = request
+    end
+
+    delegate :id, to: :@work
+    attr_reader :current_ability, :request
+
+    # @param [Array<String>] ids a list of ids to build presenters for
+    # @param [Class] presenter_class the type of presenter to build
+    # @return [Array<presenter_class>] presenters for the ordered_members (not filtered by class)
+    def member_presenters(ids = ordered_ids, presenter_class = composite_presenter_class)
+      PresenterFactory.build_for(ids: ids,
+                                 presenter_class: presenter_class,
+                                 presenter_args: presenter_factory_arguments)
+    end
+
+    # @return [Array<FileSetPresenter>] presenters for the orderd_members that are FileSets
+    def file_set_presenters
+      @file_set_presenters ||= member_presenters(ordered_ids & file_set_ids)
+      if @work.respond_to?(:transcript_id) && @work.transcript_id
+        file_set_presenters.reject! { |presenter| presenter.id == @work.transcript_id }
+      end
+    end
+
+    # @return [Array<WorkShowPresenter>] presenters for the ordered_members that are not FileSets
+    def work_presenters
+      @work_presenters ||= member_presenters(ordered_ids - file_set_ids, work_presenter_class)
+    end
+
+    def ordered_ids
+      @ordered_ids ||= Hyrax::SolrDocument::OrderedMembers.decorate(@work).ordered_member_ids
+    end
+
+    private
+
+      # These are the file sets that belong to this work, but not necessarily
+      # in order.
+      # Arbitrarily maxed at 10 thousand; had to specify rows due to solr's default of 10
+      def file_set_ids
+        @file_set_ids ||= begin
+                            ActiveFedora::SolrService.query("{!field f=has_model_ssim}FileSet",
+                                                            rows: 10_000,
+                                                            fl: ActiveFedora.id_field,
+                                                            fq: "{!join from=ordered_targets_ssim to=id}id:\"#{id}/list_source\"")
+                                                     .flat_map { |x| x.fetch(ActiveFedora.id_field, []) }
+                          end
+      end
+
+      def presenter_factory_arguments
+        [current_ability, request]
+      end
+
+      def composite_presenter_class
+        CompositePresenterFactory.new(file_presenter_class, work_presenter_class, ordered_ids & file_set_ids)
+      end
+  end
+end

--- a/app/presenters/hyrax/rcr_presenter.rb
+++ b/app/presenters/hyrax/rcr_presenter.rb
@@ -9,6 +9,8 @@ module Hyrax
       fsps.each do |fsp|
         return fsp.id if fsp.mime_type == "text/xml"
       end
+
+      return
     end
   end
 end

--- a/app/presenters/hyrax/rcr_presenter.rb
+++ b/app/presenters/hyrax/rcr_presenter.rb
@@ -10,7 +10,7 @@ module Hyrax
         return fsp.id if fsp.mime_type == "text/xml"
       end
 
-      return
+      nil
     end
   end
 end

--- a/spec/features/rcr_spec.rb
+++ b/spec/features/rcr_spec.rb
@@ -6,7 +6,8 @@ feature 'RCR' do
     FactoryBot.create(:tufts_RCR00579_rcr)
   end
 
-  let(:presenter) { instance_double("RcrPresenter", rcr_id: 's1234') }
+  # rubocop:disable RSpec/VerifiedDoubles
+  let(:presenter) { double(rcr_id: 's1234') }
 
   scenario 'View RCR00579 ("Tisch Library") page', js: true do
     visit '/concern/rcrs/s4655g578'

--- a/spec/features/rcr_spec.rb
+++ b/spec/features/rcr_spec.rb
@@ -5,7 +5,6 @@ feature 'RCR' do
   before do
     FactoryBot.create(:tufts_RCR00579_rcr)
     let(:presenter) { double(rcr_id: 's1234') }
-
   end
 
   scenario 'View RCR00579 ("Tisch Library") page', js: true do

--- a/spec/features/rcr_spec.rb
+++ b/spec/features/rcr_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 feature 'RCR' do
   before do
     FactoryBot.create(:tufts_RCR00579_rcr)
+    @presenter = double
+    allow(@presenter).to receive(:rcr_id).and_return('s1234')
   end
 
   scenario 'View RCR00579 ("Tisch Library") page', js: true do

--- a/spec/features/rcr_spec.rb
+++ b/spec/features/rcr_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 feature 'RCR' do
   before do
     FactoryBot.create(:tufts_RCR00579_rcr)
-    let(:presenter) { double(rcr_id: 's1234') }
+    let(:presenter) { instance_double("RcrPresenter", rcr_id: 's1234') }
   end
 
   scenario 'View RCR00579 ("Tisch Library") page', js: true do

--- a/spec/features/rcr_spec.rb
+++ b/spec/features/rcr_spec.rb
@@ -4,8 +4,9 @@ require 'rails_helper'
 feature 'RCR' do
   before do
     FactoryBot.create(:tufts_RCR00579_rcr)
-    let(:presenter) { instance_double("RcrPresenter", rcr_id: 's1234') }
   end
+
+  let(:presenter) { instance_double("RcrPresenter", rcr_id: 's1234') }
 
   scenario 'View RCR00579 ("Tisch Library") page', js: true do
     visit '/concern/rcrs/s4655g578'

--- a/spec/features/rcr_spec.rb
+++ b/spec/features/rcr_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 feature 'RCR' do
   before do
     FactoryBot.create(:tufts_RCR00579_rcr)
+    # rubocop:disable RSpec/VerifiedDoubles
+    @presenter = double(rcr_id: 's1234')
+    # rubocop:enable RSpec/VerifiedDoubles
   end
-
-  # rubocop:disable RSpec/VerifiedDoubles
-  let(:presenter) { double(rcr_id: 's1234') }
 
   scenario 'View RCR00579 ("Tisch Library") page', js: true do
     visit '/concern/rcrs/s4655g578'

--- a/spec/features/rcr_spec.rb
+++ b/spec/features/rcr_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 feature 'RCR' do
   before do
     FactoryBot.create(:tufts_RCR00579_rcr)
-    @presenter = double
-    allow(@presenter).to receive(:rcr_id).and_return('s1234')
+    let(:presenter) { double(rcr_id: 's1234') }
+
   end
 
   scenario 'View RCR00579 ("Tisch Library") page', js: true do

--- a/spec/presenters/hyrax/member_presenter_factory_spec.rb
+++ b/spec/presenters/hyrax/member_presenter_factory_spec.rb
@@ -1,26 +1,28 @@
+# frozen_string_literal: true
 RSpec.describe Hyrax::MemberPresenterFactory do
-    describe "#file_set_presenters" do
-      describe "getting presenters from factory" do
-        let(:solr_document) { SolrDocument.new(attributes) }
-        let(:attributes) { {} }
-        let(:ability) { double }
-        let(:request) { double }
-        let(:factory) { described_class.new(solr_document, ability, request) }
-        let(:presenter_class) { double }
+  describe "#file_set_presenters" do
+    describe "getting presenters from factory" do
+      let(:solr_document) { SolrDocument.new(attributes) }
+      let(:attributes) { {} }
+      let(:ability) { double }
+      let(:request) { double }
+      let(:factory) { described_class.new(solr_document, ability, request) }
+      let(:presenter_class) { double }
 
-        before do
-          allow(factory).to receive(:composite_presenter_class).and_return(presenter_class)
-          allow(factory).to receive(:ordered_ids).and_return(['12', '33'])
-          allow(factory).to receive(:file_set_ids).and_return(['33', '12'])
-        end
+      before do
+        allow(factory).to receive(:composite_presenter_class).and_return(presenter_class)
+        allow(factory).to receive(:ordered_ids).and_return(['12', '33'])
+        allow(factory).to receive(:file_set_ids).and_return(['33', '12'])
+      end
 
-        it "uses the set class" do
-          expect(Hyrax::PresenterFactory).to receive(:build_for)
-            .with(ids: ['12', '33'],
-                  presenter_class: presenter_class,
-                  presenter_args: [ability, request])
-          factory.file_set_presenters
-        end
+      # rubocop:disable RSpec/MessageSpies
+      it "uses the set class" do
+        expect(Hyrax::PresenterFactory).to receive(:build_for)
+          .with(ids: ['12', '33'],
+                presenter_class: presenter_class,
+                presenter_args: [ability, request])
+        factory.file_set_presenters
       end
     end
   end
+end

--- a/spec/presenters/hyrax/member_presenter_factory_spec.rb
+++ b/spec/presenters/hyrax/member_presenter_factory_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Hyrax::MemberPresenterFactory do
+    describe "#file_set_presenters" do
+      describe "getting presenters from factory" do
+        let(:solr_document) { SolrDocument.new(attributes) }
+        let(:attributes) { {} }
+        let(:ability) { double }
+        let(:request) { double }
+        let(:factory) { described_class.new(solr_document, ability, request) }
+        let(:presenter_class) { double }
+
+        before do
+          allow(factory).to receive(:composite_presenter_class).and_return(presenter_class)
+          allow(factory).to receive(:ordered_ids).and_return(['12', '33'])
+          allow(factory).to receive(:file_set_ids).and_return(['33', '12'])
+        end
+
+        it "uses the set class" do
+          expect(Hyrax::PresenterFactory).to receive(:build_for)
+            .with(ids: ['12', '33'],
+                  presenter_class: presenter_class,
+                  presenter_args: [ability, request])
+          factory.file_set_presenters
+        end
+      end
+    end
+  end

--- a/spec/presenters/hyrax/rcr_presenter_spec.rb
+++ b/spec/presenters/hyrax/rcr_presenter_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::RcrPresenter do
+  let(:presenter) { described_class.new(double, nil) }
+
+  describe '#rcr_id' do
+    context 'when file_set_presenters returns nil' do
+      before do
+        allow(presenter).to receive(:file_set_presenters).and_return(nil)
+      end
+
+      it 'returns nil' do
+        expect(presenter.rcr_id).to be_nil
+      end
+    end
+
+    context 'when there is a file_set_presenter with mime_type "text/xml"' do
+      let(:xml_fsp) { double(id: '123', mime_type: 'text/xml') }
+
+      before do
+        allow(presenter).to receive(:file_set_presenters).and_return([xml_fsp])
+      end
+
+      it 'returns the id of the xml file_set_presenter' do
+        expect(presenter.rcr_id).to eq('123')
+      end
+    end
+
+    context 'when there is no file_set_presenter with mime_type "text/xml"' do
+      let(:other_fsp) { double(id: '456', mime_type: 'text/plain') }
+
+      before do
+        allow(presenter).to receive(:file_set_presenters).and_return([other_fsp])
+      end
+
+      it 'returns nil' do
+        expect(presenter.rcr_id).to be_nil
+      end
+    end
+  end
+end

--- a/spec/presenters/hyrax/rcr_presenter_spec.rb
+++ b/spec/presenters/hyrax/rcr_presenter_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Hyrax::RcrPresenter do
     context 'when there is a file_set_presenter with mime_type "text/xml"' do
       # rubocop:disable RSpec/VerifiedDoubles:
       let(:xml_fsp) { double(id: '123', mime_type: 'text/xml') }
+      # rubocop:enable RSpec/VerifiedDoubles
 
       before do
         allow(presenter).to receive(:file_set_presenters).and_return([xml_fsp])
@@ -32,6 +33,7 @@ RSpec.describe Hyrax::RcrPresenter do
     context 'when there is file_set_presenter with mime_type "text/plain"' do
       # rubocop:disable RSpec/VerifiedDoubles:
       let(:other_fsp) { double(id: '456', mime_type: 'text/plain') }
+      # rubocop:enable RSpec/VerifiedDoubles
 
       before do
         allow(presenter).to receive(:file_set_presenters).and_return([other_fsp])

--- a/spec/presenters/hyrax/rcr_presenter_spec.rb
+++ b/spec/presenters/hyrax/rcr_presenter_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Hyrax::RcrPresenter do
     end
 
     context 'when there is a file_set_presenter with mime_type "text/xml"' do
+      # rubocop:disable RSpec/VerifiedDoubles:
       let(:xml_fsp) { double(id: '123', mime_type: 'text/xml') }
 
       before do
@@ -29,6 +30,7 @@ RSpec.describe Hyrax::RcrPresenter do
     end
 
     context 'when there is no file_set_presenter with mime_type "text/xml"' do
+      # rubocop:disable RSpec/VerifiedDoubles:
       let(:other_fsp) { double(id: '456', mime_type: 'text/plain') }
 
       before do

--- a/spec/presenters/hyrax/rcr_presenter_spec.rb
+++ b/spec/presenters/hyrax/rcr_presenter_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Hyrax::RcrPresenter do
       end
 
       it 'returns nil' do
-        expect(presenter.rcr_id).to be_nil
+        expect(presenter.rcr_id).to '456'
       end
     end
   end

--- a/spec/presenters/hyrax/rcr_presenter_spec.rb
+++ b/spec/presenters/hyrax/rcr_presenter_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Hyrax::RcrPresenter do
       end
     end
 
-    context 'when there is no file_set_presenter with mime_type "text/xml"' do
+    context 'when there is file_set_presenter with mime_type "text/plain"' do
       # rubocop:disable RSpec/VerifiedDoubles:
       let(:other_fsp) { double(id: '456', mime_type: 'text/plain') }
 
@@ -38,7 +38,7 @@ RSpec.describe Hyrax::RcrPresenter do
       end
 
       it 'returns nil' do
-        expect(presenter.rcr_id).to eq('456')
+        expect(presenter.rcr_id).to be_nil
       end
     end
   end

--- a/spec/presenters/hyrax/rcr_presenter_spec.rb
+++ b/spec/presenters/hyrax/rcr_presenter_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Hyrax::RcrPresenter do
       end
 
       it 'returns nil' do
-        expect(presenter.rcr_id).to '456'
+        expect(presenter.rcr_id).to eq('456')
       end
     end
   end


### PR DESCRIPTION
This change will hide a transcript from the associated files list of a generic object when the primary object is a video and the transcript relationship is set to make the associated file list cleaner and easier to understand for users.