### PR TITLE
updates dca to tarc in aeon integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Update rubygems
       run: |
-        gem update --system
+        gem update --system 3.3.27
         gem install bundler:2.1.4
 
     - name: Set up JDK 1.8

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get install chromium -y
 # Increase stack size limit to help working with large works
 ENV RUBY_THREAD_MACHINE_STACK_SIZE 8388608
 
-RUN gem update --system
+RUN gem update --system 3.3.27
 
 RUN mkdir /data
 WORKDIR /data

--- a/app/views/shared/_download_options.html.erb
+++ b/app/views/shared/_download_options.html.erb
@@ -14,7 +14,7 @@
           data-pid="<%= @presenter.id %>"
           download="<%= @presenter.id %>"
           data-identifier="<%= @presenter.id.gsub(/[^0-9a-z ]/i, '') %>"
-          data-site="DCA"
+          data-site="TARC"
           data-author="<%= strip_tags(@presenter.creator.first) unless @presenter.creator.empty? %>"
           data-itemauthor="<%= strip_tags(@presenter.creator.first) unless @presenter.creator.empty? %>"
           data-iteminfo2="<%= strip_tags(@presenter.creator.first) unless @presenter.creator.empty? %>"


### PR DESCRIPTION
There was a remaining field in Aeon integration where the field had to be coded 'dca', the aeon side updated today and now it needs to be 'tarc'.